### PR TITLE
fix: update action to include pipefail

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
 
     - name: Build and Test
       run: |
-        xcodebuild -workspace "${{ inputs.WORKSPACE }}" -scheme ${{ inputs.SCHEME }} test \
+        set -o pipefail && xcodebuild -workspace "${{ inputs.WORKSPACE }}" -scheme ${{ inputs.SCHEME }} test \
           -destination "${{ inputs.RUN_DESTINATION }}" \
           -enableCodeCoverage YES \
           -resultBundlePath result.xcresult | xcbeautify


### PR DESCRIPTION
# DCMAW-10099: iOS | Unit test failures not causing pipelines to fail

Previously there was no pipefail set in the action which meant that the action could fail silently on tests or in other places but the action itself would still pass. This PR amends that by implementing the pipefail.